### PR TITLE
Fix typo on nav menu so that single links show

### DIFF
--- a/home/modules/contribute/nav.adoc
+++ b/home/modules/contribute/nav.adoc
@@ -8,6 +8,6 @@
 * xref:ROOT:7lamb.adoc[7Lamb Productions]
 * xref:ROOT:trek_profiles.adoc[Trek Profiles]
 
-xref:ROOT:my_kit.adoc[My Kit]
+* xref:ROOT:my_kit.adoc[My Kit]
 
-xref:ROOT:contact.adoc[Contact Me]
+* xref:ROOT:contact.adoc[Contact Me]


### PR DESCRIPTION
Fix typo on nav menu so that single links show. Was introduced with #22.